### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.2.1",
   "description": "Usermaven JavaScript SDK.",
   "main": "dist/npm/usermaven.cjs.js",
-  "module": "dist/npm/dist/usermaven.es.js",
+  "module": "dist/npm/usermaven.es.js",
   "types": "dist/npm/usermaven.d.ts",
   "files": [
     "dist/npm/*",


### PR DESCRIPTION
Error comes as there is no dist/npm/dist/ folder generated in node-modules:  Internal server error: Failed to resolve entry for package "@usermaven/sdk-js". The package may have incorrect main/module/exports specified in its package.json.