### PR TITLE
CICD: add typescript in dockerfile

### DIFF
--- a/packages/javascript-sdk/docker/Dockerfile
+++ b/packages/javascript-sdk/docker/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:20.15.0-alpine AS builder
 WORKDIR /usr/src
 COPY . .
-RUN yarn install && yarn build
+RUN yarn install &&  yarn add typescript@latest --ignore-workspace-root-check && yarn build
 
 FROM nginx:latest
 COPY --from=builder /usr/src/packages/javascript-sdk/dist/web/lib.js /usr/share/nginx/html


### PR DESCRIPTION
### **PR Type**
enhancement, configuration changes


___

### **Description**
- Enhanced the Dockerfile to include the installation of the latest TypeScript version during the build process.
- Updated the `RUN` command in the Dockerfile to ensure TypeScript is added, facilitating TypeScript usage in the project.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Dockerfile</strong><dd><code>Add TypeScript installation to Dockerfile build process</code>&nbsp; &nbsp; </dd></summary>
<hr>

packages/javascript-sdk/docker/Dockerfile

<li>Added installation of the latest TypeScript version during the build <br>process.<br> <li> Modified the <code>RUN</code> command to include TypeScript installation.<br>


</details>


  </td>
  <td><a href="https://github.com/usermaven/usermaven-js/pull/93/files#diff-7a5f39cf5bcb819885a0b5b04234de54a0201b2149e76ad9bf4584839d6cba4e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

