### PR TITLE
fix: use beacon api check removed

### DIFF
--- a/packages/javascript-sdk/src/usermaven.ts
+++ b/packages/javascript-sdk/src/usermaven.ts
@@ -972,7 +972,7 @@ class UsermavenClientImpl implements UsermavenClient {
             this.ipPolicy = "strict";
             this.cookiePolicy = "strict";
         }
-        if (options.use_beacon_api && navigator.sendBeacon) {
+        if (navigator?.sendBeacon) {
             this.beaconApi = true;
         }
 


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Simplified the condition for enabling the beacon API by removing the check for `options.use_beacon_api` and directly checking for `navigator.sendBeacon`.
- This change ensures that the beacon API is used whenever it is available, potentially fixing issues where it was not used due to the removed condition.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>usermaven.ts</strong><dd><code>Simplify beacon API usage check in UsermavenClientImpl</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/javascript-sdk/src/usermaven.ts

<li>Removed the check for <code>options.use_beacon_api</code> before using <br><code>navigator.sendBeacon</code>.<br> <li> Simplified the condition to only check if <code>navigator.sendBeacon</code> is <br>available.<br>


</details>


  </td>
  <td><a href="https://github.com/usermaven/usermaven-js/pull/95/files#diff-a9e765a7bfd2dfbeba110d6b5d12e58d21090506ae52b206581809fae414ebfe">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

