### PR TITLE
chore: test release candidate

### DIFF
--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -2,51 +2,39 @@ name: Release Candidate
 
 on:
   pull_request:
-    types: [closed]
+    types: [ closed ]
     branches:
       - develop
 
 jobs:
-  release_candidate:
+  release_on_merge:
     runs-on: ubuntu-latest
     if: github.event.pull_request.merged == true
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
-      - name: Generate RC version
+      - name: Determine RC version
         id: rc_version
         run: |
-          # Get the latest tag
-          latest_tag=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
-          
-          # Extract version number and increment patch
-          version=$(echo $latest_tag | sed 's/^v//' | awk -F. '{$NF = $NF + 1;} 1' | sed 's/ /./g')
-          
-          # Generate RC version
-          rc_version="rc-v${version}-${{ github.run_number }}"
-          
-          echo "RC_VERSION=$rc_version" >> $GITHUB_OUTPUT
+          # Get the latest non-RC tag
+          BASE_VERSION=$(git describe --tags --abbrev=0 --match "[0-9]*.[0-9]*.[0-9]*" 2>/dev/null || echo "0.0.0")
+          # Count the number of RCs for this version
+          RC_COUNT=$(git tag -l "${BASE_VERSION}-rc.*" | wc -l)
+          RC_NUMBER=$((RC_COUNT + 1))
+          RC_VERSION="${BASE_VERSION}-rc.${RC_NUMBER}"
+          echo "RC_VERSION=${RC_VERSION}" >> $GITHUB_OUTPUT
 
-#      - name: Create Release Candidate
-#        uses: rymndhng/release-on-push-action@master
-#        with:
-#          bump_version_scheme: none
-#          tag_prefix: ""
-#          tag_name: ${{ steps.rc_version.outputs.RC_VERSION }}
-#          release_name: "Release Candidate ${{ steps.rc_version.outputs.RC_VERSION }}"
-#          release_body: |
-#            This is a release candidate created from the develop branch.
-#            RC Version: ${{ steps.rc_version.outputs.RC_VERSION }}
-#
-#            Changes in this release candidate:
-#            ${{ github.event.pull_request.title }}
-#
-#            For full changes, please see the pull request: ${{ github.event.pull_request.html_url }}
+      - id: release
+        uses: rymndhng/release-on-push-action@master
+        with:
+          bump_version_scheme: none
+          tag_name: ${{ steps.rc_version.outputs.RC_VERSION }}
+          tag_prefix: ""
+          release_name: "Release Candidate ${{ steps.rc_version.outputs.RC_VERSION }}"
 
     outputs:
-      rc_version: ${{ steps.rc_version.outputs.RC_VERSION }}
+      version: ${{ steps.release.outputs.version }}


### PR DESCRIPTION
### **PR Type**
enhancement, configuration changes


___

### **Description**
- Updated the GitHub Actions workflow for release candidates to improve versioning and release process.
- Renamed the job from `release_candidate` to `release_on_merge` for clarity.
- Simplified the checkout step by removing the explicit name.
- Changed the RC version determination logic to count existing RCs and increment accordingly.
- Re-enabled the release creation step with a new configuration to automate tagging and release naming.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>release-candidate.yml</strong><dd><code>Update release candidate workflow for improved versioning</code></dd></summary>
<hr>

.github/workflows/release-candidate.yml

<li>Renamed job from <code>release_candidate</code> to <code>release_on_merge</code>.<br> <li> Simplified code checkout step.<br> <li> Modified RC version determination to count existing RCs.<br> <li> Re-enabled release creation step with updated configuration.<br>


</details>


  </td>
  <td><a href="https://github.com/usermaven/usermaven-js/pull/128/files#diff-0ee926c5a249e740fa8422c1d356af17c9ab3f98e150ec8bdf2490aa17320aa7">+19/-31</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information