### PR TITLE
fix: respect default autoPageview config when data-auto-pageview attribute is not set

### DIFF
--- a/packages/javascript-sdk/src/index.ts
+++ b/packages/javascript-sdk/src/index.ts
@@ -68,7 +68,12 @@ function initFromScript(script: HTMLScriptElement): UsermavenClient {
         : script.getAttribute('data-form-tracking') === 'true'
           ? 'all'
           : (script.getAttribute('data-form-tracking') as 'tagged' | 'none'),
-    autoPageview: script.getAttribute('data-auto-pageview') === 'true',
+    autoPageview:
+      script.getAttribute('data-auto-pageview') === 'false'
+        ? false
+        : script.getAttribute('data-auto-pageview') === 'true'
+          ? true
+          : undefined, // Let default config handle it
     useBeaconApi: script.getAttribute('data-use-beacon-api') === 'true',
     forceUseFetch: script.getAttribute('data-force-use-fetch') === 'true',
     gaHook: script.getAttribute('data-ga-hook') === 'true',


### PR DESCRIPTION
Previously, when data-auto-pageview attribute was not provided on the script tag, it would be set to false, overriding the default config value of true.

This caused pageview tracking to be disabled by default for users who didn't explicitly set the attribute, which contradicts the SDK's intended behavior.

Changes:
- Modified initFromScript() to return undefined when data-auto-pageview is not set
- This allows the default config (autoPageview: true) to take effect
- Explicit values ('true' or 'false') still work as expected

Impact:
- Users without the attribute now get pageview tracking enabled (as intended)
- No breaking changes for users who explicitly set the attribute
- Fixes Magento 2 integration issue where pageviews weren't firing