### PR TITLE
fix(scroll-tracking): decouple scroll depth tracking from autocapture

### DIFF
--- a/packages/javascript-sdk/src/core/client.ts
+++ b/packages/javascript-sdk/src/core/client.ts
@@ -21,6 +21,7 @@ import {
 import { RetryQueue } from '../utils/queue';
 import { isWindowAvailable } from '../utils/common';
 import { RageClick } from '../extensions/rage-click';
+import { ScrollDepth } from '../extensions/scroll-depth';
 import { HttpsTransport } from '../transport/https';
 import FormTracking from '../tracking/form-tracking';
 
@@ -37,6 +38,7 @@ export class UsermavenClient {
   private anonymousId: string;
   private namespace: string;
   private rageClick?: RageClick;
+  private scrollDepth?: ScrollDepth;
 
   constructor(config: Config) {
     this.config = this.mergeConfig(config, defaultConfig);
@@ -67,6 +69,10 @@ export class UsermavenClient {
 
   private initializeBrowserFeatures(): void {
     this.cookieManager = new CookieManager(this.config.cookieDomain);
+
+    // Initialize scroll depth tracking independently of autocapture
+    this.scrollDepth = new ScrollDepth(this);
+    this.initializeScrollDepthListeners();
 
     if (
       this.config.autocapture &&
@@ -103,6 +109,36 @@ export class UsermavenClient {
 
     // Setup page leave tracking
     this.setupPageLeaveTracking();
+  }
+
+  private initializeScrollDepthListeners(): void {
+    if (!this.scrollDepth) return;
+
+    const scrollDepth = this.scrollDepth;
+
+    const isPageRefresh = (): boolean => {
+      if ('PerformanceNavigationTiming' in window) {
+        const perfEntries = performance.getEntriesByType('navigation');
+        if (perfEntries.length > 0) {
+          const navEntry = perfEntries[0] as PerformanceNavigationTiming;
+          return navEntry.type === 'reload';
+        }
+      }
+      return performance.navigation && performance.navigation.type === 1;
+    };
+
+    const handleSendScroll = () => {
+      if (!isPageRefresh()) {
+        scrollDepth.send();
+      }
+    };
+
+    document.addEventListener('visibilitychange', () => {
+      if (document.visibilityState === 'hidden') {
+        handleSendScroll();
+      }
+    });
+    window.addEventListener('popstate', handleSendScroll);
   }
 
   /**

--- a/packages/javascript-sdk/src/core/client.ts
+++ b/packages/javascript-sdk/src/core/client.ts
@@ -39,6 +39,8 @@ export class UsermavenClient {
   private namespace: string;
   private rageClick?: RageClick;
   private scrollDepth?: ScrollDepth;
+  private scrollDepthVisibilityHandler?: () => void;
+  private scrollDepthPopstateHandler?: () => void;
 
   constructor(config: Config) {
     this.config = this.mergeConfig(config, defaultConfig);
@@ -71,6 +73,7 @@ export class UsermavenClient {
     this.cookieManager = new CookieManager(this.config.cookieDomain);
 
     // Initialize scroll depth tracking independently of autocapture
+    this.destroyScrollDepth();
     this.scrollDepth = new ScrollDepth(this);
     this.initializeScrollDepthListeners();
 
@@ -133,12 +136,29 @@ export class UsermavenClient {
       }
     };
 
-    document.addEventListener('visibilitychange', () => {
+    this.scrollDepthVisibilityHandler = () => {
       if (document.visibilityState === 'hidden') {
         handleSendScroll();
       }
-    });
-    window.addEventListener('popstate', handleSendScroll);
+    };
+    this.scrollDepthPopstateHandler = handleSendScroll;
+
+    document.addEventListener('visibilitychange', this.scrollDepthVisibilityHandler);
+    window.addEventListener('popstate', this.scrollDepthPopstateHandler);
+  }
+
+  private destroyScrollDepth(): void {
+    if (this.scrollDepth) {
+      this.scrollDepth.destroy();
+    }
+    if (this.scrollDepthVisibilityHandler) {
+      document.removeEventListener('visibilitychange', this.scrollDepthVisibilityHandler);
+      this.scrollDepthVisibilityHandler = undefined;
+    }
+    if (this.scrollDepthPopstateHandler) {
+      window.removeEventListener('popstate', this.scrollDepthPopstateHandler);
+      this.scrollDepthPopstateHandler = undefined;
+    }
   }
 
   /**

--- a/packages/javascript-sdk/src/tracking/autocapture.ts
+++ b/packages/javascript-sdk/src/tracking/autocapture.ts
@@ -3,8 +3,6 @@ import {
   _each,
   _extend,
   _includes,
-  _isFunction,
-  _isUndefined,
   _register_event,
   _safewrap_instance_methods,
 } from '../utils/common';
@@ -24,7 +22,6 @@ import {
   isDocumentFragment,
 } from '../utils/autocapture-utils';
 import { getLogger } from '../utils/logger';
-import { ScrollDepth } from '../extensions/scroll-depth';
 import { UsermavenClient } from '@/core/client';
 import { Config } from '../core/types';
 import {
@@ -36,7 +33,6 @@ import {
 class AutoCapture {
   private client: UsermavenClient;
   private options: Config;
-  private scrollDepth: ScrollDepth | null = null;
   private customProperties: AutoCaptureCustomProperty[] = [];
   private domHandlersAttached: boolean = false;
 
@@ -51,7 +47,6 @@ class AutoCapture {
   ) {
     this.client = client;
     this.options = options;
-    this.scrollDepth = new ScrollDepth(client);
     _bind_instance_methods(this);
     _safewrap_instance_methods(this);
   }
@@ -95,21 +90,6 @@ class AutoCapture {
     _register_event(document, 'submit', handler, false, true);
     _register_event(document, 'change', handler, false, true);
     _register_event(document, 'click', handler, false, true);
-    _register_event(document, 'visibilitychange', handler, false, true);
-    _register_event(document, 'scroll', handler, false, true);
-    _register_event(window, 'popstate', handler, false, true);
-  }
-
-  private isPageRefresh(): boolean {
-    if ('PerformanceNavigationTiming' in window) {
-      const perfEntries = performance.getEntriesByType('navigation');
-      if (perfEntries.length > 0) {
-        const navEntry = perfEntries[0] as PerformanceNavigationTiming;
-        return navEntry.type === 'reload';
-      }
-    }
-    // Fallback to the old API if PerformanceNavigationTiming is not supported
-    return performance.navigation && performance.navigation.type === 1;
   }
 
   private captureEvent(e: Event): boolean | void {
@@ -117,22 +97,6 @@ class AutoCapture {
     let target = this.getEventTarget(e);
     if (isTextNode(target)) {
       target = (target.parentNode || null) as Element | null;
-    }
-
-    if (e.type === 'scroll') {
-      this.scrollDepth?.track();
-      return true;
-    }
-
-    if (
-      (e.type === 'visibilitychange' &&
-        document.visibilityState === 'hidden') ||
-      e.type === 'popstate'
-    ) {
-      if (!this.isPageRefresh()) {
-        this.scrollDepth?.send();
-      }
-      return true;
     }
 
     if (!target || !isElementNode(target)) {

--- a/packages/javascript-sdk/test/e2e/scroll-depth-test.html
+++ b/packages/javascript-sdk/test/e2e/scroll-depth-test.html
@@ -148,9 +148,9 @@
                 const checkInterval = setInterval(() => {
                     // Get the script tag client instance
                     const client = window.usermavenScriptTagClient ? window.usermavenScriptTagClient() : null;
-                    if (client && client.autoCapture && client.autoCapture.scrollDepth) {
+                    if (client && client.scrollDepth) {
                         usermavenClient = client;
-                        scrollDepthInstance = client.autoCapture.scrollDepth;
+                        scrollDepthInstance = client.scrollDepth;
                         clearInterval(checkInterval);
                         resolve(true);
                     }


### PR DESCRIPTION
**PROBLEM:**
Scroll events were not firing when data-autocapture attribute was missing or set to false. This affected customers who wanted scroll tracking but not full autocapture functionality.

**ROOT CAUSE:**
ScrollDepth was tightly coupled to AutoCapture class:
- ScrollDepth instance was created inside AutoCapture constructor
- AutoCapture was only initialized when data-autocapture="true"
- If autocapture was disabled, ScrollDepth was never instantiated
- Result: No scroll event tracking even though it's independent functionality

This architectural coupling meant:
1-Pageview events worked (independent of autocapture)
2- Pageleave events worked (independent of autocapture)
3-Scroll events failed (coupled to autocapture)

**SOLUTION:**
Moved ScrollDepth initialization from AutoCapture to UsermavenClient:
1. ScrollDepth now initializes in initializeBrowserFeatures() independently
2. Moved scroll event listeners from AutoCapture to dedicated method
3. Removed ScrollDepth dependency from AutoCapture class
4. Scroll tracking now works regardless of autocapture setting

**CHANGES:**
- **client.ts:**
  * Added scrollDepth property to UsermavenClient
  * Initialize ScrollDepth in initializeBrowserFeatures() before autocapture
  * Created initializeScrollDepthListeners() to handle scroll events
  * Moved isPageRefresh() logic from AutoCapture to client

- **autocapture.ts:**
  * Removed scrollDepth property and initialization
  * Removed scroll, visibilitychange, and popstate event handlers
  * Removed isPageRefresh() method (moved to client)
  * Removed scroll-related event handling from captureEvent()

**IMPACT:**
- Scroll depth tracking now works independently of autocapture
- Customers can disable autocapture but still get scroll events
- No breaking changes - existing functionality preserved
- Better separation of concerns and modularity
