### PR TITLE
fix(pageview): route initial pageview through RetryQueue with flushImmediately

### DIFF
--- a/packages/javascript-sdk/src/core/client.ts
+++ b/packages/javascript-sdk/src/core/client.ts
@@ -18,7 +18,7 @@ import {
   isValidEmail,
   parseQueryString,
 } from '../utils/helpers';
-import { RetryQueue } from '../utils/queue';
+import { RetryQueue, QueueAddOptions } from '../utils/queue';
 import { isWindowAvailable } from '../utils/common';
 import { RageClick } from '../extensions/rage-click';
 import { ScrollDepth } from '../extensions/scroll-depth';
@@ -417,6 +417,7 @@ export class UsermavenClient {
     typeName: string,
     payload?: EventPayload,
     directSend: boolean = false,
+    options: QueueAddOptions = {},
   ): void {
     // Check if user has opted out of tracking
     const umExclusionState = getUmExclusionState();
@@ -449,7 +450,7 @@ export class UsermavenClient {
         this.logger.debug(`Event sent: ${typeName}`, [eventPayload]);
         return;
       }
-      this.retryQueue.add(eventPayload);
+      this.retryQueue.add(eventPayload, options);
       this.logger.debug(`Event tracked: ${typeName}`, [eventPayload]);
     } catch (error) {
       this.logger.error(`Failed to track event: ${typeName}`, error);
@@ -621,6 +622,7 @@ export class UsermavenClient {
     return utmParams;
   }
 
+  // Manual pageview intentionally ignores autoPageview; callers use this when they own pageview timing.
   public pageview(): void {
     if (isWindowAvailable()) {
       this.track(
@@ -633,6 +635,7 @@ export class UsermavenClient {
         true,
       );
     } else {
+      // Pageview tracking requires browser APIs (window.location, document); not available server-side.
       this.logger.warn(
         'Pageview tracking is not available in server-side environments',
       );
@@ -775,4 +778,34 @@ export class UsermavenClient {
       `Event type: ${eventType || 'global'}`,
     );
   }
+}
+
+// Must mirror the private trackInternal() signature exactly. TypeScript cannot enforce this
+// because the cast through unknown strips type safety. Update both if trackInternal changes.
+type InternalTrackableClient = {
+  trackInternal(
+    typeName: string,
+    payload?: EventPayload,
+    directSend?: boolean,
+    options?: QueueAddOptions,
+  ): void;
+};
+
+// Not exported from index.ts — for SDK-internal initialization only (script-tag/GTM).
+// Routes through the queue for retry and offline support; flushImmediately attempts to send the event immediately
+export function captureInitialPageview(client: UsermavenClient): void {
+  if (!isWindowAvailable()) {
+    return;
+  }
+
+  (client as unknown as InternalTrackableClient).trackInternal(
+    'pageview',
+    {
+      url: window.location.href,
+      referrer: document.referrer,
+      title: document.title,
+    },
+    false,
+    { flushImmediately: true },
+  );
 }

--- a/packages/javascript-sdk/src/index.ts
+++ b/packages/javascript-sdk/src/index.ts
@@ -1,4 +1,4 @@
-import { UsermavenClient } from './core/client';
+import { UsermavenClient, captureInitialPageview } from './core/client';
 import { defaultConfig } from './core/config';
 import type { Config } from './core/types';
 import { LogLevel } from './utils/logger';
@@ -135,9 +135,9 @@ function initFromScript(script: HTMLScriptElement): UsermavenClient {
   const client = usermavenClient(config);
   const namespace = config.namespace || 'usermaven';
 
-  // Only send pageview if auto-pageview is enabled (default behavior for script tag)
-  if (isWindowAvailable()) {
-    client.pageview();
+  // Send pageview unless explicitly disabled via data-auto-pageview='false'
+  if (isWindowAvailable() && config.autoPageview !== false) {
+    captureInitialPageview(client);
   }
 
   initializeNamespacedClient(namespace, client);

--- a/packages/javascript-sdk/src/tracking/pageviews.ts
+++ b/packages/javascript-sdk/src/tracking/pageviews.ts
@@ -1,5 +1,8 @@
 import { UsermavenClient } from '../core/client';
-
+/**
+ * Tracks SPA URL changes after the first page load.
+ * Initial pageview is sent by script-tag init or explicit client.pageview() calls.
+ */
 export class PageviewTracking {
   private client: UsermavenClient;
   private lastPageUrl: string;
@@ -11,6 +14,15 @@ export class PageviewTracking {
     this.initializePageviewTracking();
   }
 
+  /**
+   * No-op by design: lastPageUrl is set to window.location.href before this runs,
+   * and trackPageview() only sends after a URL change. Initial pageview is owned
+   * by script-tag init or explicit client.pageview() calls.
+   *
+   * If we change this to emit the initial pageview, UsermavenClient must initialize
+   * anonymousId before constructing PageviewTracking, because pageview payloads
+   * read anonymousId during event creation.
+   */
   private trackInitialPageview(): void {
     this.trackPageview();
   }
@@ -47,6 +59,7 @@ export class PageviewTracking {
     const currentUrl = window.location.href;
     if (currentUrl !== this.lastPageUrl) {
       this.lastPageUrl = currentUrl;
+      // SPA navigations don't share the initial load's unload risk, so flushImmediately is not needed.
       this.client.track('pageview', {
         url: currentUrl,
         referrer: document.referrer,

--- a/packages/javascript-sdk/src/utils/queue.ts
+++ b/packages/javascript-sdk/src/utils/queue.ts
@@ -36,7 +36,7 @@ export class RetryQueue {
     }
   }
 
-  add(payload: any): void {
+  add(payload: any, options: QueueAddOptions = {}): void {
     const item = {
       payload,
       retries: 0,
@@ -48,6 +48,11 @@ export class RetryQueue {
     this.enforceQueueLimits();
     if (isWindowAvailable()) {
       this.saveQueueToStorage();
+      if (options.flushImmediately) {
+        // If processBatch() is already running this will not send immediately
+        // the item will be picked up by the next scheduleBatch(). Acceptable degradation.
+        void this.processBatch();
+      }
     } else {
       this.processBatch(); // Immediately process on server-side
     }
@@ -215,6 +220,10 @@ export class RetryQueue {
       this.persistence.set('queue', JSON.stringify(serializableQueue));
     }
   }
+}
+
+export interface QueueAddOptions {
+  flushImmediately?: boolean;
 }
 
 interface QueueItem {

--- a/packages/javascript-sdk/test/e2e/magento-requirejs.spec.ts
+++ b/packages/javascript-sdk/test/e2e/magento-requirejs.spec.ts
@@ -410,6 +410,11 @@ test.describe('Magento Integration Summary', () => {
         { timeout: 15000 }
       );
 
+      await page.waitForFunction(
+        () => window.magentoTestResults?.usermavenTracking === true,
+        { timeout: 5000 }
+      );
+
       const results = await page.evaluate(() => window.magentoTestResults);
 
       if (!results) throw new Error('Test results not available');

--- a/packages/javascript-sdk/test/e2e/namespace.spec.ts
+++ b/packages/javascript-sdk/test/e2e/namespace.spec.ts
@@ -248,13 +248,12 @@ test.describe('Usermaven Namespace Tests', () => {
         })
         .filter(Boolean);
 
-      // Check if all namespaces sent pageviews (current SDK behavior sends pageviews for all namespaces)
+      // Only namespaces with auto-pageview enabled should send an initial pageview.
       expect(pageviewNamespaces).toContain('usermaven');
       expect(pageviewNamespaces).toContain('analytics');
-      expect(pageviewNamespaces).toContain('tracker');
+      expect(pageviewNamespaces).not.toContain('tracker');
 
-      // All 3 namespaces should send pageviews with current SDK implementation
-      expect(pageviewEvents.length).toBe(3);
+      expect(pageviewEvents.length).toBe(2);
 
       // Now manually trigger a pageview with the tracker namespace
       await page.evaluate(() => {
@@ -266,7 +265,7 @@ test.describe('Usermaven Namespace Tests', () => {
       // Wait for the event to be processed
       await page.waitForTimeout(2000);
 
-      // Verify that now we have 4 pageview events (3 automatic + 1 manual)
+      // Verify that now we have 3 pageview events (2 automatic + 1 manual)
       const updatedPageviewEvents = requests.filter((req) => {
         if (!req.postData) return false;
         try {
@@ -278,7 +277,7 @@ test.describe('Usermaven Namespace Tests', () => {
         }
       });
 
-      expect(updatedPageviewEvents.length).toBe(4);
+      expect(updatedPageviewEvents.length).toBe(3);
 
       // Verify there's a pageview from the tracker namespace
       const trackerPageview = updatedPageviewEvents.find((req) => {

--- a/packages/javascript-sdk/test/unit/core/client.test.ts
+++ b/packages/javascript-sdk/test/unit/core/client.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { UsermavenClient } from '../../../src/core/client';
+import { UsermavenClient, captureInitialPageview } from '../../../src/core/client';
 import { Config } from '../../../src/core/types';
 
 describe('UsermavenClient', () => {
@@ -9,6 +9,7 @@ describe('UsermavenClient', () => {
     key: 'test-api-key',
     trackingHost: 'https://test.usermaven.com',
     tracking_host: 'https://test.usermaven.com',
+    autoPageview: false,
   };
 
   beforeEach(() => {
@@ -32,9 +33,9 @@ describe('UsermavenClient', () => {
       expect(client['retryQueue'].add).not.toHaveBeenCalled();
     });
 
-    it('should throw an error for invalid email', () => {
+    it('should throw an error for invalid email', async () => {
       const userData = { id: 'user123', email: 'invalid-email' };
-      expect(() => client.id(userData)).rejects.toThrow(
+      await expect(() => client.id(userData)).rejects.toThrow(
         'Invalid email provided',
       );
     });
@@ -174,9 +175,9 @@ describe('UsermavenClient', () => {
       expect(client.track).not.toHaveBeenCalled();
     });
 
-    it('should throw an error for invalid company properties', () => {
+    it('should throw an error for invalid company properties', async () => {
       const invalidProps = { id: 'company123' };
-      expect(() => client.group(invalidProps as any)).rejects.toThrow(
+      await expect(client.group(invalidProps as any)).rejects.toThrow(
         'Company properties must include id, name, and created_at',
       );
     });
@@ -194,6 +195,29 @@ describe('UsermavenClient', () => {
           title: expect.any(String),
         }),
         true,
+      );
+    });
+  });
+
+  describe('captureInitialPageview', () => {
+    it('should enqueue initial pageview with flushImmediately without using public pageview direct send', () => {
+      captureInitialPageview(client);
+
+      expect(client.track).not.toHaveBeenCalled();
+
+      expect(addSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          event_type: 'pageview',
+          event_attributes: expect.objectContaining({
+            url: expect.any(String),
+            referrer: expect.any(String),
+            title: expect.any(String),
+          }),
+          user: expect.objectContaining({
+            anonymous_id: expect.any(String),
+          }),
+        }),
+        { flushImmediately: true },
       );
     });
   });

--- a/packages/javascript-sdk/test/unit/utils/queue.test.ts
+++ b/packages/javascript-sdk/test/unit/utils/queue.test.ts
@@ -53,6 +53,39 @@ describe('RetryQueue', () => {
     );
   });
 
+  it('should call transport.send immediately when flushImmediately is true', async () => {
+    const payload = { data: 'test' };
+
+    retryQueue.add(payload, { flushImmediately: true });
+    await vi.runOnlyPendingTimersAsync();
+
+    expect(mockPersistence.set).toHaveBeenCalledWith(
+      'queue',
+      expect.any(String),
+    );
+    expect(mockTransport.send).toHaveBeenCalledWith([payload]);
+  });
+
+  it('should requeue and retry when flushImmediately send fails', async () => {
+    const payload = { data: 'test' };
+
+    mockTransport.send.mockRejectedValueOnce(new Error('Network error'));
+    mockTransport.send.mockResolvedValueOnce(undefined);
+
+    retryQueue.add(payload, { flushImmediately: true });
+
+    // Allow processBatch() to complete: transport.send rejects, item is requeued
+    await vi.runOnlyPendingTimersAsync();
+    expect(mockTransport.send).toHaveBeenCalledTimes(1);
+
+    // Advance past retryInterval (set inside handleBatchFailure), then fire the next batch
+    await vi.advanceTimersByTimeAsync(retryQueue['retryInterval']);
+    await vi.runOnlyPendingTimersAsync();
+
+    expect(mockTransport.send).toHaveBeenCalledTimes(2);
+    expect(mockTransport.send).toHaveBeenLastCalledWith([payload]);
+  });
+
   it('should process batch when online', async () => {
     const payload1 = { data: 'test1' };
     const payload2 = { data: 'test2' };


### PR DESCRIPTION
**Problem**

1. Lost initial pageviews – The initial pageview used directSend: true, a fire‑and‑forget call to transport.send() that completely bypassed the RetryQueue. Customers on slow connections or with deeplink races lost their first pageview event. In fast‑navigation scenarios (e.g., deep‑link redirects), the request often never completed before the browser unloaded.
2. autoPageview: false ignored – initFromScript() called client.pageview() unconditionally, ignoring the data‑auto-pageview="false" attribute. Customers who explicitly opted out of automatic pageview tracking still received one.

**Solution**

New module‑level function `captureInitialPageview(client)` — introduced in `src/core/client.ts`. It is not a class method and is not re‑exported from `index.ts`, keeping it off the public API.

- Calls the private `trackInternal()` directly with `{ flushImmediately: true }`
- Routes the event through `RetryQueue` while triggering an immediate flush attempt so the event is not held until the next batch interval
- The public `client.pageview()` method remains unchanged — it keeps `directSend: true` for manually‑triggered pageview calls. `flushImmediately` is applied only to the initial script‑tag / GTM load path.

**What did not change**

- `PageviewTracking` is not involved in the initial pageview — it remains SPA‑only
- `client.pageview()` public behaviour is identical to before this branch
- npm/framework installs that call `client.pageview()` manually are unaffected
- No public API additions — `captureInitialPageview` is intentionally not re‑exported from `index.ts`
- No bundle size impact (~200–300 bytes in a 55KB bundle; types and comments are stripped at build time)

**Testing**

- Unit tests – `captureInitialPageview` verifies routing through `retryQueue.add` with `{ flushImmediately: true }` and correct payload shape
- Queue unit tests – `flushImmediately` triggers immediate `transport.send`; failed send requeues and retries
- E2E – namespace spec updated to verify `autoPageview: false` is respected; Magento spec timing race fixed